### PR TITLE
Changing URL to hey.kleinfreund.de (subdomain)

### DIFF
--- a/jekyll.ini
+++ b/jekyll.ini
@@ -81,8 +81,8 @@ source = https://raw.github.com/planetjekyll/planet/master/jekyll.ini
 
 [kleinfreund]
   title    = Philipp Rudloff @ Weimar › Germany
-  link     = http://kleinfreund.de/en
-  feed     = http://kleinfreund.de/en/feed.xml
+  link     = http://hey.kleinfreund.de/en/
+  feed     = http://hey.kleinfreund.de/en/feed.xml
   includes = Jekyll|GitHub Pages
   github   = kleinfreund
 


### PR DESCRIPTION
I moved my site to a subdomain because the Initial Connection to GitHub Pages took around 3-5 seconds (making up for about 90 % of my page load time).
